### PR TITLE
docs: refresh QUICKSTART for the PolkaVM/PPN dev loop + add container guide

### DIFF
--- a/docs/CONTAINER_DEV.md
+++ b/docs/CONTAINER_DEV.md
@@ -6,9 +6,11 @@ private-repo PPN checkout, a patched sibling clone of
 `contract-dependency-manager`). If you'd rather not splatter all of that
 across your host, here are two container recipes that work on Linux.
 
-> **Not tested on macOS/Windows.** Docker Desktop's filesystem and networking
-> layers will work but with overhead. The Linux-native distrobox path below
-> is the smoothest.
+> On Linux, the distrobox path below is the smoothest. On macOS there's no
+> host network and no native containers — you need a Linux VM underneath
+> Docker/Podman. See [macOS](#macos-orbstack--colima--docker-desktop) below
+> for a working recipe. Windows is not covered here, but WSL2 + the Linux
+> distrobox or podman recipe should work.
 
 ## Recommended: distrobox (Fedora 43+ host)
 
@@ -131,16 +133,92 @@ distros without SELinux.
 - **`pkill -9 -f …`** in `start.sh` is process-namespace-scoped inside a
   container, so it can't reach host processes — which is what you want.
 
+## macOS (OrbStack / Colima / Docker Desktop)
+
+There is no native Linux container on macOS — every option puts a small
+Linux VM under the hood, then runs containers inside it. That means:
+
+- **No host networking** for the container; you must forward each port.
+- **Bind-mount performance** depends on the VM's filesystem driver
+  (VirtioFS-class drivers are fast enough; older 9P/NFS paths are noticeably
+  slower for Rust builds).
+- **PPN binaries are Linux ELFs**, fetched by `make ensure-deps` for whatever
+  arch the *container* reports. They run inside the Linux VM regardless of
+  whether your Mac is Apple Silicon or Intel. Don't try to launch them on
+  the host shell.
+
+### Option A: OrbStack (recommended on Apple Silicon)
+
+[OrbStack](https://orbstack.dev) is the smoothest dev experience on macOS
+today — fast VirtioFS bind mounts, low memory footprint, native arm64.
+It speaks the docker CLI, so the [podman recipe above](#alternative-rootless-podman)
+works almost verbatim — substitute `docker` for `podman` and drop the SELinux
+`:Z` suffix:
+
+```bash
+brew install orbstack            # then launch OrbStack.app once
+
+docker build -t oab-dev -f Containerfile .
+docker run --rm -it \
+  -v "$PWD":/workspace \
+  -p 5173:5173 -p 10000:10000 -p 10010:10010 \
+  -p 10020:10020 -p 10030:10030 -p 8080:8080 \
+  oab-dev bash
+```
+
+Then inside the container, follow QUICKSTART Path 2 (clone PPN, clone the
+sibling cdm repo, `./start.sh`). Browse to <http://localhost:5173> from your
+Mac browser — OrbStack forwards the published ports to host `localhost`.
+
+OrbStack can also create lightweight Linux machines directly
+(`orb create ubuntu oab && orb -m oab bash`) if you'd rather skip Docker and
+treat the VM like a distrobox shell. That works too, but the container
+approach is more reproducible.
+
+### Option B: Colima (open-source CLI)
+
+[Colima](https://github.com/abiosoft/colima) gives you a Lima-backed Docker
+runtime without Docker Desktop's licensing or UI overhead. Allocate enough
+resources up front — PPN + the Rust toolchain are not light:
+
+```bash
+brew install colima docker
+colima start --cpu 4 --memory 8 --disk 60 --vm-type vz --mount-type virtiofs
+```
+
+`vz` + `virtiofs` (macOS 13+) is the fast path; on older macOS, Colima falls
+back to QEMU + sshfs which is workable but slower for Cargo. Then use the same
+`docker build` / `docker run` invocation as the OrbStack section.
+
+### Option C: Docker Desktop
+
+Docker Desktop works but is the heaviest of the three. If your org already
+pays for it, the same commands apply. Make sure to bump the VM resources
+(Settings → Resources → CPUs ≥ 4, Memory ≥ 8 GB, Disk ≥ 60 GB) before the
+first `cargo build`, otherwise the contract build will OOM.
+
+### macOS caveats specific to this project
+
+- **`gh auth login`** still required (PPN repo is private). Easiest: do the
+  auth on your Mac host, then bind-mount `~/.config/gh` read-only into the
+  container — `gh` inside the VM will pick up the same token.
+- **`./start.sh`'s `pkill -9 -f …`** only affects the container's PID
+  namespace, so it can't kill anything on your Mac. Fine.
+- **macOS firewall / Little Snitch**: first browser hit to
+  <http://localhost:5173> may prompt; allow once.
+- **Resource ceiling**: PPN spawns several `polkadot-omni-node` workers plus
+  IPFS. On an 8 GB Mac you'll be tight; 16 GB+ is the comfortable floor.
+
 ## Trade-offs
 
-| Concern                       | distrobox       | podman rootless   |
-|---                            |---              |---                |
-| Setup ceremony                | minimal         | Containerfile     |
-| Host isolation                | low (home mount)| high              |
-| Browser-from-host on `:5173`  | works (host net)| needs `-p 5173`   |
-| Reuse host editor / git creds | yes             | requires bind/share |
-| Reproducibility               | medium          | high              |
+| Concern                       | distrobox (Linux) | podman rootless (Linux) | macOS (OrbStack/Colima/Docker Desktop) |
+|---                            |---                |---                       |---                                     |
+| Setup ceremony                | minimal           | Containerfile            | Containerfile + a VM runtime           |
+| Host isolation                | low (home mount)  | high                     | high (separate VM)                     |
+| Browser-from-host on `:5173`  | works (host net)  | needs `-p 5173`          | needs `-p 5173` (forwarded by VM)      |
+| Reuse host editor / git creds | yes               | requires bind/share      | works via bind mount                   |
+| Bind-mount perf for Rust      | native            | native                   | VirtioFS-class on recent macOS         |
+| Reproducibility               | medium            | high                     | high                                   |
 
-If in doubt, start with distrobox — you can always rebuild from a clean
-container if anything goes sideways, and the workflow is closest to running
-the tooling directly on your host.
+If in doubt: distrobox on Linux, OrbStack on macOS. Both let you rebuild from
+a clean container if anything goes sideways.

--- a/docs/CONTAINER_DEV.md
+++ b/docs/CONTAINER_DEV.md
@@ -1,0 +1,146 @@
+# Container-based Dev Setup
+
+The OAB on-chain loop pulls in a non-trivial pile of toolchain pieces (Rust
+nightly, `cargo-pvm-contract` from a specific branch, `bun`, `wasm-pack`, a
+private-repo PPN checkout, a patched sibling clone of
+`contract-dependency-manager`). If you'd rather not splatter all of that
+across your host, here are two container recipes that work on Linux.
+
+> **Not tested on macOS/Windows.** Docker Desktop's filesystem and networking
+> layers will work but with overhead. The Linux-native distrobox path below
+> is the smoothest.
+
+## Recommended: distrobox (Fedora 43+ host)
+
+`distrobox` runs a container that mounts your `$HOME`, shares your X/Wayland
+session, and uses host networking — so PPN's ports (`10000–10030`, `8080`)
+and Vite's `5173` just work, and the bind-mounted repo means edits from your
+host editor are visible inside.
+
+```bash
+# 1. Create the container (Fedora base; Debian/Ubuntu also fine)
+distrobox create --name oab --image fedora:43
+
+# 2. Enter it
+distrobox enter oab
+
+# 3. Install the toolchain (inside the container)
+sudo dnf install -y git make gcc gcc-c++ cmake pkg-config openssl-devel \
+  protobuf-compiler clang nodejs npm curl unzip
+
+# Rust + nightly
+curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+source "$HOME/.cargo/env"
+rustup toolchain install nightly --component rust-src --profile minimal
+
+# wasm-pack + cargo-pvm-contract (charles/cdm-integration)
+cargo install wasm-pack
+HOST_TARGET=$(rustc -vV | grep '^host:' | cut -d' ' -f2)
+git clone -b charles/cdm-integration \
+  https://github.com/paritytech/cargo-pvm-contract.git /tmp/cpvm
+cargo install --force --locked --target "$HOST_TARGET" \
+  --path /tmp/cpvm/crates/cargo-pvm-contract
+
+# bun ≥ 1.2 for the cdm CLI
+curl -fsSL https://bun.sh/install | bash
+echo 'export PATH="$HOME/.bun/bin:$PATH"' >> ~/.bashrc
+export PATH="$HOME/.bun/bin:$PATH"
+
+# gh, for cloning the private PPN repo
+sudo dnf install -y gh
+gh auth login
+```
+
+Then follow `docs/QUICKSTART.md` Path 2 from inside the container. Because
+the repo lives on your host filesystem (bind-mounted into the container),
+`./start.sh` writes WASM artefacts back to your host tree and the dev server
+serves them out normally.
+
+### Why host networking matters here
+
+`start.sh`'s `pkill -9 -f "$PPN_DIR/bin/polkadot"` cleans up zombienet
+descendants by absolute path — works fine inside a container, and won't reach
+host processes. With distrobox's default networking, the Vite server on
+`:5173` and Asset Hub on `:10020` are reachable from your host browser
+without any `-p` flags.
+
+## Alternative: rootless podman
+
+If you want stricter isolation (no host-home mount), a `Containerfile`-based
+flow works too. Sketch:
+
+```Dockerfile
+# Containerfile
+FROM fedora:43
+
+RUN dnf install -y git make gcc gcc-c++ cmake pkg-config openssl-devel \
+      protobuf-compiler clang nodejs npm curl unzip gh \
+ && curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y \
+ && . "$HOME/.cargo/env" \
+ && rustup toolchain install nightly --component rust-src --profile minimal \
+ && cargo install wasm-pack
+
+# bun
+RUN curl -fsSL https://bun.sh/install | bash
+ENV PATH="/root/.bun/bin:/root/.cargo/bin:${PATH}"
+
+# cargo-pvm-contract (specific branch)
+RUN git clone -b charles/cdm-integration \
+      https://github.com/paritytech/cargo-pvm-contract.git /tmp/cpvm \
+ && HOST_TARGET=$(rustc -vV | grep '^host:' | cut -d' ' -f2) \
+ && cargo install --force --locked --target "$HOST_TARGET" \
+      --path /tmp/cpvm/crates/cargo-pvm-contract \
+ && rm -rf /tmp/cpvm
+
+WORKDIR /workspace
+```
+
+Build and run:
+
+```bash
+podman build -t oab-dev -f Containerfile .
+podman run --rm -it \
+  -v "$PWD":/workspace:Z \
+  -p 5173:5173 -p 10000:10000 -p 10010:10010 \
+  -p 10020:10020 -p 10030:10030 -p 8080:8080 \
+  oab-dev bash
+
+# Inside the container:
+gh auth login                       # PPN repo is private
+git clone --depth 1 --branch main \
+  https://github.com/paritytech/product-preview-net.git ppn
+cd ppn && make ensure-deps
+cd ..
+# ...then the rest of QUICKSTART Path 2.
+```
+
+The `:Z` SELinux relabel on the bind mount is required on Fedora; drop it on
+distros without SELinux.
+
+### Caveats
+
+- **PPN binary download** (~250 MB) goes into `ppn/bin/` which is on the
+  bind-mounted repo, so it survives container rebuilds — don't add `ppn/`
+  to a `.dockerignore`.
+- **`cargo` and `~/.cargo`** should live on a persistent volume if you plan
+  to rebuild often, otherwise every `podman run` redownloads crates. Add
+  `-v oab-cargo:/root/.cargo`.
+- **GitHub auth.** Either run `gh auth login` interactively inside the
+  container each session, or bind-mount `~/.config/gh:/root/.config/gh:ro`
+  from the host.
+- **`pkill -9 -f …`** in `start.sh` is process-namespace-scoped inside a
+  container, so it can't reach host processes — which is what you want.
+
+## Trade-offs
+
+| Concern                       | distrobox       | podman rootless   |
+|---                            |---              |---                |
+| Setup ceremony                | minimal         | Containerfile     |
+| Host isolation                | low (home mount)| high              |
+| Browser-from-host on `:5173`  | works (host net)| needs `-p 5173`   |
+| Reuse host editor / git creds | yes             | requires bind/share |
+| Reproducibility               | medium          | high              |
+
+If in doubt, start with distrobox — you can always rebuild from a clean
+container if anything goes sideways, and the workflow is closest to running
+the tooling directly on your host.

--- a/docs/CONTAINER_DEV.md
+++ b/docs/CONTAINER_DEV.md
@@ -80,7 +80,8 @@ curl -fsSL https://bun.sh/install | bash
 echo 'export PATH="$HOME/.bun/bin:$PATH"' >> ~/.bashrc
 export PATH="$HOME/.bun/bin:$PATH"
 
-# gh login (PPN repo is private)
+# gh login — the PPN installer is public, but it clones a private repo
+# (paritytech/product-preview-net) underneath, so this is required.
 gh auth login
 ```
 
@@ -196,11 +197,10 @@ podman run --rm -it \
   oab-dev bash
 
 # Inside the container:
-gh auth login                       # PPN repo is private
-git clone --depth 1 --branch main \
-  https://github.com/paritytech/product-preview-net.git ppn
-cd ppn && make ensure-deps
-cd ..
+gh auth login                       # PPN's network repo is private
+curl -sL https://raw.githubusercontent.com/paritytech/ppn-proxy/main/install.sh | bash
+# → clones ./ppn from the private paritytech/product-preview-net and
+#   runs `make ensure-deps` (~250 MB).
 # ...then the rest of QUICKSTART Path 2.
 ```
 
@@ -290,9 +290,11 @@ first `cargo build`, otherwise the contract build will OOM.
 
 ### macOS caveats specific to this project
 
-- **`gh auth login`** still required (PPN repo is private). Easiest: do the
-  auth on your Mac host, then bind-mount `~/.config/gh` read-only into the
-  container — `gh` inside the VM will pick up the same token.
+- **`gh auth login`** still required — the PPN installer is public, but it
+  clones `paritytech/product-preview-net` underneath which is private.
+  Easiest: do the auth on your Mac host, then bind-mount `~/.config/gh`
+  read-only into the container — `gh` inside the VM will pick up the same
+  token.
 - **`./start.sh`'s `pkill -9 -f …`** only affects the container's PID
   namespace, so it can't kill anything on your Mac. Fine.
 - **macOS firewall / Little Snitch**: first browser hit to

--- a/docs/CONTAINER_DEV.md
+++ b/docs/CONTAINER_DEV.md
@@ -12,23 +12,55 @@ across your host, here are two container recipes that work on Linux.
 > for a working recipe. Windows is not covered here, but WSL2 + the Linux
 > distrobox or podman recipe should work.
 
-## Recommended: distrobox (Fedora 43+ host)
+## Recommended: distrobox (any Linux host)
 
 `distrobox` runs a container that mounts your `$HOME`, shares your X/Wayland
 session, and uses host networking — so PPN's ports (`10000–10030`, `8080`)
 and Vite's `5173` just work, and the bind-mounted repo means edits from your
 host editor are visible inside.
 
+### Install distrobox on the host
+
+`distrobox` is a thin wrapper around podman/docker — install one of those
+plus `distrobox` itself using your distro's package manager:
+
 ```bash
-# 1. Create the container (Fedora base; Debian/Ubuntu also fine)
+# Fedora / RHEL / CentOS Stream / Rocky / Alma
+sudo dnf install -y distrobox podman
+
+# Debian / Ubuntu (distrobox is in the universe / contrib repos)
+sudo apt-get install -y distrobox podman
+
+# Arch / Manjaro
+sudo pacman -S --needed distrobox podman
+
+# openSUSE
+sudo zypper install -y distrobox podman
+
+# Nix / NixOS
+nix-shell -p distrobox podman      # or add to your config
+```
+
+If your distro ships an older `distrobox` (< 1.7), grab the upstream installer
+instead: `curl -s https://raw.githubusercontent.com/89luca89/distrobox/main/install | sh`.
+
+### Bring up the container
+
+The container image is independent of your host — pick whichever feels
+familiar. We use Fedora below; swap `--image fedora:43` for
+`ubuntu:24.04`, `debian:trixie`, etc., and adjust the `dnf install` step to
+the matching package manager (see the variant block beneath).
+
+```bash
+# 1. Create the container (any base works; pick the one you know best)
 distrobox create --name oab --image fedora:43
 
 # 2. Enter it
 distrobox enter oab
 
-# 3. Install the toolchain (inside the container)
+# 3. Install the toolchain (inside the container — Fedora variant)
 sudo dnf install -y git make gcc gcc-c++ cmake pkg-config openssl-devel \
-  protobuf-compiler clang nodejs npm curl unzip
+  protobuf-compiler clang nodejs npm curl unzip gh
 
 # Rust + nightly
 curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
@@ -48,10 +80,30 @@ curl -fsSL https://bun.sh/install | bash
 echo 'export PATH="$HOME/.bun/bin:$PATH"' >> ~/.bashrc
 export PATH="$HOME/.bun/bin:$PATH"
 
-# gh, for cloning the private PPN repo
-sudo dnf install -y gh
+# gh login (PPN repo is private)
 gh auth login
 ```
+
+**Debian/Ubuntu variant** — replace step 3's `dnf` line with:
+
+```bash
+sudo apt-get update && sudo apt-get install -y \
+  git make gcc g++ cmake pkg-config libssl-dev protobuf-compiler \
+  clang curl unzip ca-certificates gh
+# Node 20 LTS via NodeSource (or your preferred method)
+curl -fsSL https://deb.nodesource.com/setup_20.x | sudo -E bash -
+sudo apt-get install -y nodejs
+```
+
+**Arch variant**:
+
+```bash
+sudo pacman -S --needed git make gcc cmake pkgconf openssl protobuf clang \
+  nodejs npm curl unzip github-cli
+```
+
+Everything after step 3 (rustup, wasm-pack, `cargo-pvm-contract`, bun, gh
+login) is identical across distros.
 
 Then follow `docs/QUICKSTART.md` Path 2 from inside the container. Because
 the repo lives on your host filesystem (bind-mounted into the container),
@@ -71,8 +123,12 @@ without any `-p` flags.
 If you want stricter isolation (no host-home mount), a `Containerfile`-based
 flow works too. Sketch:
 
+The `Containerfile` below uses a Fedora base — substitute `ubuntu:24.04` /
+`debian:trixie` and switch `dnf` to `apt-get` if you prefer (the container
+image is independent of your host distro):
+
 ```Dockerfile
-# Containerfile
+# Containerfile (Fedora base)
 FROM fedora:43
 
 RUN dnf install -y git make gcc gcc-c++ cmake pkg-config openssl-devel \
@@ -97,6 +153,38 @@ RUN git clone -b charles/cdm-integration \
 WORKDIR /workspace
 ```
 
+<details>
+<summary>Debian-base equivalent (click to expand)</summary>
+
+```Dockerfile
+FROM debian:trixie-slim
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+      git make gcc g++ cmake pkg-config libssl-dev protobuf-compiler \
+      clang curl unzip ca-certificates gh \
+ && curl -fsSL https://deb.nodesource.com/setup_20.x | bash - \
+ && apt-get install -y nodejs \
+ && rm -rf /var/lib/apt/lists/* \
+ && curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y \
+ && . "$HOME/.cargo/env" \
+ && rustup toolchain install nightly --component rust-src --profile minimal \
+ && cargo install wasm-pack
+
+RUN curl -fsSL https://bun.sh/install | bash
+ENV PATH="/root/.bun/bin:/root/.cargo/bin:${PATH}"
+
+RUN git clone -b charles/cdm-integration \
+      https://github.com/paritytech/cargo-pvm-contract.git /tmp/cpvm \
+ && HOST_TARGET=$(rustc -vV | grep '^host:' | cut -d' ' -f2) \
+ && cargo install --force --locked --target "$HOST_TARGET" \
+      --path /tmp/cpvm/crates/cargo-pvm-contract \
+ && rm -rf /tmp/cpvm
+
+WORKDIR /workspace
+```
+
+</details>
+
 Build and run:
 
 ```bash
@@ -116,8 +204,11 @@ cd ..
 # ...then the rest of QUICKSTART Path 2.
 ```
 
-The `:Z` SELinux relabel on the bind mount is required on Fedora; drop it on
-distros without SELinux.
+The `:Z` SELinux relabel on the bind mount is required on SELinux-enforcing
+hosts (Fedora, RHEL, CentOS Stream, Rocky, Alma — and Debian/Ubuntu if you've
+enabled SELinux explicitly). Drop the suffix on distros running AppArmor or
+no MAC layer (default Debian/Ubuntu, Arch, openSUSE Tumbleweed, NixOS). If
+you're unsure: `sestatus` — if it says `SELinux status: enabled` you need `:Z`.
 
 ### Caveats
 

--- a/docs/CURRENT_ARCHITECTURE.md
+++ b/docs/CURRENT_ARCHITECTURE.md
@@ -1,6 +1,33 @@
-# Open Auto Battler: Current Architecture (January 30, 2026)
+# Open Auto Battler: Architecture (legacy snapshot)
 
-This document describes the current architecture of Open Auto Battler, an auto-battler game where the battle engine runs identically in the browser (via WASM) and on a blockchain (via Substrate pallet).
+> **⚠️ OUTDATED — kept for historical reference only.**
+>
+> This document describes the **pre-migration Substrate-pallet** architecture
+> (a `pallet-auto-battle` pallet, an `oab-core` crate under `core/`, and a
+> `blockchain/` directory). None of that exists in the tree any more.
+>
+> The current chain backend is a **PolkaVM smart contract** under
+> [`contract/`](../contract/) running on Polkadot Asset Hub (`pallet-revive`).
+> The engine has been split into the `battle/`, `game/`, and `assets/` crates.
+> Storage/IO is no longer a pallet — it's contract entry points
+> (`startGame`, `submitTurn`, etc., see `contract/README.md`).
+>
+> For the **current** architecture, read:
+> - [`agents/ARCHITECTURE.md`](../agents/ARCHITECTURE.md) — system map
+> - [`agents/CORE_ENGINE.md`](../agents/CORE_ENGINE.md) — engine internals
+> - [`agents/WASM_BRIDGE.md`](../agents/WASM_BRIDGE.md) — Rust ↔ JS boundary
+> - [`contract/README.md`](../contract/README.md) — contract + PPN dev loop
+>
+> The conceptual pieces below (SCALE encoding for chain transport, the
+> shared-Rust-engine principle, the ability system, battle execution limits)
+> are still accurate in spirit, but every code path, crate name, and file
+> reference has changed. Trust the agent docs first.
+
+---
+
+This document describes the **historical** architecture of Open Auto Battler,
+an auto-battler game where the battle engine ran identically in the browser
+(via WASM) and on a blockchain (via Substrate pallet).
 
 ## High-Level Overview
 

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -1,175 +1,197 @@
 # Quick Start Guide
 
-Get up and running with Open Auto Battler development in 5 minutes.
+Get running with Open Auto Battler development. The on-chain path is heavier
+than a single dev node — it boots a local Polkadot Preview Network (PPN). If
+you only want to look at the game, the WASM-only path is much lighter.
 
-## Prerequisites
+> **Authoritative deep-dive:** [`contract/README.md`](../contract/README.md)
+> covers the full PolkaVM contract / PPN / `@dotdm/cdm` setup. This document
+> is a shorter on-ramp.
 
-- Rust (latest stable)
-- Node.js 18+ & pnpm
-- wasm-pack (`cargo install wasm-pack`)
+## Two paths
 
-## Quick Start (All-in-One)
+| Path                   | What runs                                | Setup effort  |
+|---                     |---                                       |---            |
+| **WASM-only**          | Engine + React UI (no chain)             | ~5 minutes    |
+| **Full on-chain loop** | PPN zombienet + PolkaVM contract + UI    | ~30–60 min*   |
 
-```bash
-# From project root - builds WASM, starts chain, starts web UI
-./start.sh
-```
+\* mostly toolchain installs and a ~250 MB binary download for PPN.
 
-Open http://localhost:5173 when ready.
+If you prefer to keep all of this isolated from your host, see
+[CONTAINER_DEV.md](./CONTAINER_DEV.md) for a distrobox/podman recipe.
 
-## Manual Setup
+---
 
-### 1. Build WASM Client
+## Path 1 — WASM-only (engine + UI, no chain)
+
+This builds the deterministic battle engine to WASM and serves the React UI.
+On-chain routes won't work, but you can verify the toolchain and explore the
+codebase quickly.
+
+### Prerequisites
+
+- Rust stable (engine + WASM bridge do not need nightly)
+- `wasm-pack`: `cargo install wasm-pack`
+- Node.js 20+ and npm (the `web/` workspace uses npm — `package-lock.json` is
+  the source of truth)
+
+### Run
 
 ```bash
 # From project root
-./build-wasm.sh
+./build-wasm.sh                       # compiles client/ to WASM, copies to web/src/wasm
+cd web && npm install && npm run dev  # Vite dev server on :5173
 ```
 
-This compiles `client/` to WASM and copies artifacts to `web/src/wasm/`.
+Open <http://localhost:5173>. The `/#/contract` route requires the on-chain
+stack (Path 2); other routes render against the local WASM engine.
 
-### 2. Run the Web UI
+---
+
+## Path 2 — Full on-chain loop (PPN + contract + UI)
+
+This is what `./start.sh` automates. Setup is non-trivial because the contract
+runs on PolkaVM (`pallet-revive` on Asset Hub), the frontend talks to it via
+`@dotdm/cdm` over PAPI, and a local Polkadot Preview Network supplies the
+relay + Asset Hub + IPFS infrastructure.
+
+### Prerequisites
+
+Beyond Path 1's tools:
+
+- **Rust nightly + `rust-src`** (only the contract crate needs it — the engine
+  compiles on stable):
+  ```bash
+  rustup toolchain install nightly --component rust-src --profile minimal
+  ```
+- **`cargo-pvm-contract`** from the `charles/cdm-integration` branch:
+  ```bash
+  HOST_TARGET=$(rustc -vV | grep '^host:' | cut -d' ' -f2)
+  git clone -b charles/cdm-integration \
+    https://github.com/paritytech/cargo-pvm-contract.git /tmp/cpvm
+  cargo install --force --locked --target "$HOST_TARGET" \
+    --path /tmp/cpvm/crates/cargo-pvm-contract
+  ```
+- **`bun` ≥ 1.2** (the cdm CLI is bun-compiled; bun 1.1 hits a PAPI rxjs bug):
+  ```bash
+  curl -fsSL https://bun.sh/install | bash
+  export PATH="$HOME/.bun/bin:$PATH"   # add to your shell rc
+  ```
+- **`gh auth login`** — PPN's upstream repo is private (`paritytech/product-preview-net`).
+
+### Two extra clones
+
+The dev loop expects two extra repos alongside `open-auto-battler/`:
+
+1. **PPN zombienet** (cloned *inside* this repo at `./ppn/`):
+   ```bash
+   cd open-auto-battler
+   git clone --depth 1 --branch main \
+     https://github.com/paritytech/product-preview-net.git ppn
+   cd ppn && make ensure-deps    # ~250 MB of chain binaries + specs
+   ```
+
+2. **Sibling `contract-dependency-manager` clone** with a patched
+   `REGISTRY_ADDRESS` (cdm hardcodes the registry address for a specific
+   bytecode hash that locally-built registries don't reproduce — see
+   [`contract/README.md`](../contract/README.md) for the why):
+   ```bash
+   cd ..   # alongside open-auto-battler/
+   git clone https://github.com/paritytech/contract-dependency-manager.git
+   cd contract-dependency-manager
+   pnpm install
+   make build-registry
+   make deploy-registry CHAIN=local      # one-time on a fresh chain
+   # Patch REGISTRY_ADDRESS to the deployed address from the previous step:
+   sed -i.bak \
+     's|"0xae344f7f0f91d3a2176032af2990abcc7606c7d4"|"<DEPLOYED_ADDR>"|' \
+     src/lib/utils/src/constants.ts
+   ```
+
+If your cdm clone lives elsewhere, set `CDM_SRC=/path/to/clone` before running
+`start.sh`.
+
+### Boot it
 
 ```bash
-cd web
-pnpm install
-pnpm dev
+./start.sh                  # full bootstrap (registry + contract + cards + web)
+./start.sh --no-bootstrap   # subsequent runs against the same chain
 ```
 
-Open http://localhost:5173. You will see the **Login Page**. To play, you need a running blockchain (see step 3).
+`start.sh` will:
 
-### 3. Run with Blockchain
+1. Build the WASM engine (`./build-wasm.sh`).
+2. Boot PPN zombienet (`cd ppn && make start EPHEMERAL=1`).
+3. Wait for Asset Hub at `ws://127.0.0.1:10020`.
+4. (Bootstrap only) Build and deploy the cdm `ContractRegistry`, then deploy
+   the OAB contract; otherwise just redeploy OAB.
+5. Refresh `web/cdm.json` + typed bindings via `cdm install`.
+6. Generate card/set bytes (`oab-register-cards --dump`) and register them
+   via `Utility.batch_all` (~25 s for 114 calls).
+7. Start the Vite dev server on `:5173`.
 
-#### Terminal 1: Start the chain
+Open <http://localhost:5173/#/contract>, click **DEV ACCOUNTS** → pick Alice
+→ **Contract Arena** → **Start Game**.
 
-```bash
-cd blockchain
-./start_chain.sh
-```
+### Endpoints PPN exposes
 
-Wait for block production to start (you'll see block numbers incrementing).
+| Chain          | URL                          |
+|---             |---                           |
+| Paseo Relay    | `ws://127.0.0.1:10000`       |
+| People Chain   | `ws://127.0.0.1:10010`       |
+| **Asset Hub**  | `ws://127.0.0.1:10020`       |
+| Bulletin Chain | `ws://127.0.0.1:10030`       |
+| IPFS gateway   | `http://127.0.0.1:8080/ipfs` |
 
-#### Terminal 2: Start the web UI
-
-```bash
-cd web
-pnpm dev
-```
-
-Open http://localhost:5173. On the Login Page, connect to the chain, select an account, and log in. From the Main Menu, navigate to **Play > Online Arena** (on-chain) or **Play > Offline** (local WASM). For card testing without a game, go to **Cards > Sandbox**.
-
-## Project Structure at a Glance
-
-```
-auto-battle/
-├── core/          # The heart: battle engine, shared by browser & chain
-├── client/        # WASM wrapper around core for browser
-├── blockchain/    # Substrate runtime + auto-battle pallet
-├── web/           # React frontend
-└── docs/          # You are here
-```
+---
 
 ## Development Workflow
 
-### Making Game Logic Changes
+### Engine changes (`battle/`, `game/`, `assets/`)
 
-1. Edit files in `core/src/`
-2. Run tests: `cd core && cargo test`
-3. Rebuild WASM: `./build-wasm.sh`
-4. Refresh browser
+1. Edit the relevant crate.
+2. `cargo test -p oab-battle` (or the crate you touched).
+3. `./build-wasm.sh` to rebuild the browser bundle.
+4. Reload the browser tab.
 
-### Making UI Changes
+### UI changes (`web/`)
 
-1. Edit files in `web/src/`
-2. Changes hot-reload automatically
+Vite hot-reloads — just edit and save.
 
-### Making Blockchain Changes
+### Contract changes (`contract/src/main.rs`)
 
-1. Edit files in `blockchain/pallets/auto-battle/src/`
-2. Restart the chain: `cd blockchain && ./start_chain.sh`
-3. Refresh browser and reconnect
+Re-running `./start.sh` (without `--no-bootstrap`) cleanly redeploys. Or build
+manually:
 
-## Common Tasks
+```bash
+cd contract
+env -u CARGO -u RUSTUP_TOOLCHAIN \
+  cargo pvm-contract build --manifest-path "$(pwd)/Cargo.toml" -p oab-contract
+```
 
-### Add a new card
+The absolute `--manifest-path` is required — `cargo-pvm-contract` v0.3.0 has a
+relative-path bug. See `contract/README.md` for the full contract API and
+selector table.
 
-Edit `core/src/units.rs`:
-- Add to the card set definition in `get_card_set()`
-- Define abilities in the `UnitCard` struct
-
-### Add a new ability
-
-Edit `core/src/battle.rs`:
-- Add variant to ability enums
-- Implement in `execute_ability()` or relevant trigger handler
-
-### Modify turn validation
-
-Edit `core/src/commit.rs`:
-- `verify_and_apply_turn()` validates all player actions
+---
 
 ## Running Tests
 
 ```bash
-# Core engine tests (from project root)
-cargo test -p oab-core
-
-# Pallet tests (from project root)
-cargo test -p pallet-auto-battle
+cargo test --workspace          # full Rust workspace
+cargo test -p oab-battle        # just the battle engine
 ```
 
-## Core Coverage
+The web tests (if any) live under `web/` and use Vite's runner — `cd web && npm test`.
 
-```bash
-# One-time install
-cargo install cargo-llvm-cov
-rustup component add llvm-tools-preview
+---
 
-# Generate core coverage summary + reports
-./core/coverage.sh
-```
+## Where to read next
 
-Coverage outputs:
-- Summary printed to stdout
-- `target/coverage/oab-core/lcov.info`
-- `target/coverage/oab-core/html/index.html`
-
-Optional minimum line coverage gate:
-
-```bash
-FAIL_UNDER_LINES=80 ./core/coverage.sh
-```
-
-Optional engine-critical gate (focuses on `battle/commit/state/limits` by ignoring
-`log/opponents/units/view/rng/types`):
-
-```bash
-FAIL_UNDER_LINES=80 ENGINE_FAIL_UNDER_LINES=80 ./core/coverage.sh
-```
-
-CI currently enforces `80%` total line coverage and `80%` engine-critical line coverage.
-
-## Debugging
-
-### Browser Console
-
-The WASM engine logs to console. Look for:
-- `[INFO]` - Normal operations
-- `[DEBUG]` - Detailed state (enable in `core/src/log.rs`)
-
-### Chain Logs
-
-Omni Node outputs block info and extrinsic results.
-
-### State Inspection
-
-In Online Arena mode, the UI shows:
-- Current chain state (decoded from SCALE)
-- Action log (what will be submitted)
-- Battle events (combat resolution)
-
-## Next Steps
-
-- Read [CURRENT_ARCHITECTURE.md](./CURRENT_ARCHITECTURE.md) for deep dive
-- Check `core/src/tests/` for examples of game mechanics
-- Look at existing cards in `core/src/units.rs` for patterns
+- [`agents/AGENTS.md`](../agents/AGENTS.md) — canonical agent + architecture
+  index. Start here if you're contributing.
+- [`agents/ARCHITECTURE.md`](../agents/ARCHITECTURE.md) — current system map.
+- [`contract/README.md`](../contract/README.md) — full PolkaVM / PPN / cdm
+  setup, contract API, and the upstream patches the dev loop depends on.
+- [CONTAINER_DEV.md](./CONTAINER_DEV.md) — running the whole toolchain inside
+  a container.

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -77,18 +77,23 @@ Beyond Path 1's tools:
   curl -fsSL https://bun.sh/install | bash
   export PATH="$HOME/.bun/bin:$PATH"   # add to your shell rc
   ```
-- **`gh auth login`** — PPN's upstream repo is private (`paritytech/product-preview-net`).
+- **`gh auth login`** — the PPN installer lives in the public
+  `paritytech/ppn-proxy` repo, but it clones `paritytech/product-preview-net`
+  underneath, which **is private**. Without GitHub auth the install step
+  fails partway through.
 
 ### Two extra clones
 
 The dev loop expects two extra repos alongside `open-auto-battler/`:
 
-1. **PPN zombienet** (cloned *inside* this repo at `./ppn/`):
+1. **PPN zombienet** (cloned *inside* this repo at `./ppn/`). Use the
+   installer from `paritytech/ppn-proxy` — it clones the network repo and
+   runs `make ensure-deps` for you (~250 MB of chain binaries + specs).
+   `gh auth login` must already be done because the installer's internal
+   clone targets a private repo:
    ```bash
    cd open-auto-battler
-   git clone --depth 1 --branch main \
-     https://github.com/paritytech/product-preview-net.git ppn
-   cd ppn && make ensure-deps    # ~250 MB of chain binaries + specs
+   curl -sL https://raw.githubusercontent.com/paritytech/ppn-proxy/main/install.sh | bash
    ```
 
 2. **Sibling `contract-dependency-manager` clone** with a patched

--- a/docs/README.md
+++ b/docs/README.md
@@ -4,29 +4,42 @@
 
 Start here:
 
-1. **[QUICKSTART.md](./QUICKSTART.md)** - Get running in 5 minutes
-2. **[CURRENT_ARCHITECTURE.md](./CURRENT_ARCHITECTURE.md)** - How everything fits together
+1. **[QUICKSTART.md](./QUICKSTART.md)** — get the WASM-only path running fast,
+   or follow the full PPN setup for the on-chain loop.
+2. **[../agents/ARCHITECTURE.md](../agents/ARCHITECTURE.md)** — the current
+   system map. (The local `CURRENT_ARCHITECTURE.md` is a legacy snapshot of
+   the pre-migration pallet-based design and should not be used as a guide.)
+3. **[CONTAINER_DEV.md](./CONTAINER_DEV.md)** — distrobox/podman recipes for
+   running the whole toolchain in a Linux container.
 
 ## Other Documentation
 
-For detailed agent and architecture docs, see the [agents/](../agents/) folder.
+The canonical agent and architecture docs live in [`../agents/`](../agents/) —
+`AGENTS_INDEX.md` is the entry point, with linked deep dives for the engine,
+WASM bridge, web UI, serialization contracts, and testing.
+
+`../contract/README.md` is the authoritative reference for the PolkaVM
+contract, the PPN dev loop, and the upstream patches the loop currently
+depends on.
 
 ## Architecture Highlights
 
 ```
-┌─────────────────────────────────────────────────────────┐
-│                    oab-core                       │
-│              (Rust - runs everywhere)                   │
-└────────────────────────┬────────────────────────────────┘
-                         │
-          ┌──────────────┼──────────────┐
-          ▼                             ▼
-┌─────────────────────┐      ┌─────────────────────┐
-│   WASM (Browser)    │      │  Pallet (Chain)     │
-│   Fast iteration    │      │  Authoritative      │
-│   Local preview     │◄────►│  Verifies actions   │
-└─────────────────────┘      └─────────────────────┘
-                 SCALE encoding
+┌────────────────────────────────────────────────────────────┐
+│                Rust engine (battle/, game/, assets/)       │
+│             pure, deterministic, runs everywhere           │
+└──────────────────────────┬─────────────────────────────────┘
+                           │
+            ┌──────────────┼──────────────┐
+            ▼                             ▼
+┌─────────────────────┐         ┌─────────────────────────┐
+│   WASM (browser)    │         │   PolkaVM contract      │
+│  client/ → web/     │◄───────►│   contract/ on Asset Hub│
+│  fast iteration     │  SCALE  │   authoritative arena   │
+└─────────────────────┘         └─────────────────────────┘
+                  Same Rust types both sides
 ```
 
-Key insight: The browser and blockchain run the **exact same** battle logic. SCALE encoding ensures byte-perfect compatibility.
+Key insight: the browser and the contract execute the **exact same** battle
+logic from the shared engine crates. SCALE encoding (via `parity_scale_codec`)
+keeps the bytes byte-perfect across the boundary.


### PR DESCRIPTION
## Summary

`docs/QUICKSTART.md`, `docs/CURRENT_ARCHITECTURE.md`, and `docs/README.md` still describe the pre-migration Substrate-pallet world (`core/`, `blockchain/`, `pallet-auto-battle`, pnpm + stable Rust). None of that path works against the current `contract/` + PPN + `@dotdm/cdm` setup, which the rest of the repo (especially `agents/` and `contract/README.md`) has already moved to. This PR brings `docs/` into line.

- **Rewrite `docs/QUICKSTART.md`** with two paths:
  - *WASM-only* (engine + React UI, no chain) — `wasm-pack`, stable Rust, ~5 min.
  - *Full on-chain loop* — nightly Rust + `rust-src`, `cargo-pvm-contract` from `charles/cdm-integration`, `bun ≥ 1.2`, PPN clone, sibling `contract-dependency-manager` clone with patched `REGISTRY_ADDRESS`. Defers to `contract/README.md` for full detail.
- **`docs/CURRENT_ARCHITECTURE.md`**: add an OUTDATED banner pointing readers at `agents/ARCHITECTURE.md` + `contract/README.md`. Body left intact as a historical snapshot of the pallet-based design rather than risking a partial rewrite.
- **`docs/README.md`**: update the ASCII diagram and crate labels to reflect the `battle/`/`game/`/`assets/` split and the PolkaVM contract (instead of `oab-core` + "Pallet (Chain)").
- **New `docs/CONTAINER_DEV.md`**: distrobox-first recipe (host networking so PPN ports 10000–10030, IPFS 8080, and Vite 5173 just work; repo bind-mounted) plus a podman `Containerfile` alternative for stricter isolation. Notes the PPN `~250 MB` binary download, `gh auth login` requirement for the private repo, and persistent-volume tips for `~/.cargo`.

No code changes — docs only.

## Test plan

- [x] All new prerequisite commands match `contract/README.md` (nightly install, `cargo-pvm-contract` branch, bun install, PPN clone, cdm sibling clone with patched `REGISTRY_ADDRESS`).
- [x] No remaining references to `core/`, `blockchain/`, `pallet-auto-battle`, `oab-core` crate, or `pnpm` in the rewritten docs.
- [x] Path 1 (WASM-only) matches the actual scripts: `./build-wasm.sh` (wasm-pack) → `cd web && npm install && npm run dev`. `web/package-lock.json` confirms npm.
- [x] Path 2 endpoint table matches `start.sh` (`ws://127.0.0.1:10020` for Asset Hub, `:8080/ipfs` for IPFS gateway).
- [x] Distrobox recipe relies only on host networking + bind mount; podman recipe forwards the right port set.
- [ ] @shawntabrizi to skim — there may be conventions around the docs/ folder I haven't picked up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)